### PR TITLE
 Fix parsing issues

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -216,21 +216,27 @@ namespace NATPlugin
 
                 // Some entries may contain multiple tracks
                 while (true) {
-                    if (Array.IndexOf(words, "TRACK") == -1) {
+                    var trackIdx = words.IndexOf("TRACK");
+
+                    // If words doesn't contain the word TRACK, we are done processing this entry
+                    if (trackIdx == -1) {
                         break;
                     }
 
-                    var routeIdx = Array.IndexOf(words, "FLEX");
-                    var trackIdx = Array.IndexOf(words, "TRACK");
+                    var routeIdx = words.IndexOf("FLEX");
                     var trackIdTemp = words[trackIdx + 1];
                     // Remove period after the track id
                     var trackId = trackIdTemp.Substring(0, trackIdTemp.Length - 1);
                     var fixes = new List<Fix>();
+                    int cutoffIdx = 0;
 
-                    for (int rt_i = routeIdx + 3; rt_i < words.Length; rt_i++)
+                    for (int rt_i = routeIdx + 3; rt_i < words.Count; rt_i++)
                     {
+                        // If the current word is RMK or the word after is ROUTE, assume that
+                        // this is no longer part of the flex route so break out of for-loop
                         if (words[rt_i + 1] == "ROUTE" || words[rt_i] == "RMK")
                         {
+                            cutoffIdx = rt_i;
                             break;
                         }
                         var point = words[rt_i];
@@ -275,6 +281,7 @@ namespace NATPlugin
                     }
 
                     tracks.Add(new Track(trackId, start, end, fixes));
+                    // Grab slice after the flex route to see if there are any more tracks to process
                     words =  words.Skip(cutoffIdx).ToArray<string>();
                 }
             }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -214,6 +214,7 @@ namespace NATPlugin
                 var start = new DateTime(startYear, startMonth, startDay, startHour, startMin, 0);
                 var end = new DateTime(endYear, endMonth, endDay, endHour, endMin, 0);
 
+                // Some entries may contain multiple tracks
                 while (true) {
                     if (Array.IndexOf(words, "TRACK") == -1) {
                         break;
@@ -228,8 +229,7 @@ namespace NATPlugin
 
                     for (int rt_i = routeIdx + 3; rt_i < words.Length; rt_i++)
                     {
-                        string[] _next_route  = {"ROUTE", "RMK"};
-                        if (_next_route.Contains(words[rt_i + 1]))
+                        if (words[rt_i + 1] == "ROUTE" || words[rt_i] == "RMK")
                         {
                             break;
                         }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -215,7 +215,8 @@ namespace NATPlugin
                 var end = new DateTime(endYear, endMonth, endDay, endHour, endMin, 0);
 
                 // Some entries may contain multiple tracks
-                while (true) {
+                while (true)
+                {
                     var trackIdx = words.IndexOf("TRACK");
 
                     // If words doesn't contain the word TRACK, we are done processing this entry
@@ -282,7 +283,7 @@ namespace NATPlugin
 
                     tracks.Add(new Track(trackId, start, end, fixes));
                     // Grab slice after the flex route to see if there are any more tracks to process
-                    words =  words.Skip(cutoffIdx).ToArray<string>();
+                    words = words.Skip(cutoffIdx).ToArray<string>();
                 }
             }
 


### PR DESCRIPTION
* Remove period from track id
* Fix parsing entries that contains multiple tracks

e.g.
```
    Q1621/24 - EASTBOUND PACOTS TRACKS BETWEEN JAPAN AND NORTH AMERICA,
    TRACK 1.
     FLEX ROUTE : KALNA 44N160E 46N170E 48N180E 50N170W 51N160W 51N150W
                  50N140W PRETY
    JAPAN ROUTE : ADNAP OTR5 KALNA
      NAR ROUTE : ACFT LDG KSEA/KPDX--PRETY TOU KSEA/KPDX
                  ACFT LDG CYVR--PRETY GOVAD CYVR
            RMK : ACFT LDG OTHER DEST--PRETY UPR TO DEST
    TRACK 2.
     FLEX ROUTE : EMRON 42N160E 44N170E 45N180E 46N170W 46N160W 45N150W
                  42N140W 40N130W SHENU
    JAPAN ROUTE : ADNAP OTR7 EMRON
      NAR ROUTE : ACFT LDG KSFO--SHENU AMAKR BGGLO KSFO
                  ACFT LDG KLAX--SHENU ENI OAK BURGL IRNMN KLAX
    TRACK 3.
     FLEX ROUTE : LEPKI 41N160E 43N170E 44N180E 45N170W 45N160W 44N150W
                  41N140W 39N130W DACEM
    JAPAN ROUTE : AVBET OTR11 LEPKI
      NAR ROUTE : ACFT LDG KLAX--DACEM PAINT PIRAT BURGL IRNMN KLAX
                  ACFT LDG KSFO--DACEM PAINT PIRAT OSI KSFO
            RMK : ATM CENTER TEL:81-92-608-8870. 25 JUN 07:00 2024 UNTIL 25 JUN
    21:00 2024. CREATED: 24 JUN 17:16 2024
```

```
1
KALNA 44N160E 46N170E 48N180E 50N170W 51N160W 51N150W 50N140W PRETY
2
EMRON 42N160E 44N170E 45N180E 46N170W 46N160W 45N150W 42N140W 40N130W SHENU
3
LEPKI 41N160E 43N170E 44N180E 45N170W 45N160W 44N150W 41N140W 39N130W DACEM
```
